### PR TITLE
Update Parameter Store Costructors

### DIFF
--- a/parameter_store_client_test.go
+++ b/parameter_store_client_test.go
@@ -65,8 +65,7 @@ func TestClient_GetParametersByPath(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			client := new(ParameterStore)
-			client.SetSSM(test.ssmClient)
+			client := NewParameterStoreWithClient(test.ssmClient)
 			parameters, err := client.GetAllParametersByPath(test.path, true)
 			if err != test.expectedError {
 				t.Errorf(`Unexpected error: got %d, expected %d`, err, test.expectedError)


### PR DESCRIPTION
Update constructors to not be very Paddle specific.
Breaking Public API by removing exported methods that are not used by anyone internally (lets break things before we open-source it) 😬 
Closes #10 