### PR TITLE
PutSecureParameter and recursive GetAllParametersByPath

### DIFF
--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -36,9 +36,7 @@ func (ps *ParameterStore) GetAllParametersByPath(path string, decrypt bool) (*Pa
 	var input = &ssm.GetParametersByPathInput{}
 	input.SetWithDecryption(decrypt)
 	input.SetPath(path)
-  // yes, this is hard-coded, but if you have a directory of more than 100 records, maybe you 
-  // should think about re-organizing :)
-  input.SetMaxResults(50)
+  input.SetRecursive(true)
 	return ps.getParameters(input)
 }
 

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -127,7 +127,7 @@ func (ps *ParameterStore) putParameter(input *ssm.PutParameterInput) error {
 	_, err := ps.ssm.PutParameter(input)
 	if err != nil {
 		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == ssm.ErrCodeParameterAlreadyExists {
-      return ErrParameterInvalidName
+			return ErrParameterInvalidName
 		}
 		return err
 	}

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -126,8 +126,8 @@ func (ps *ParameterStore) putSecureParameterWrapper(name, value, kmsID string, o
 func (ps *ParameterStore) putParameter(input *ssm.PutParameterInput) error {
 	_, err := ps.ssm.PutParameter(input)
 	if err != nil {
-		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == ssm.ErrCodeParameterNotFound {
-			return ErrParameterNotFound
+		if awsError, ok := err.(awserr.Error); ok && awsError.Code() == ssm.ErrCodeParameterAlreadyExists {
+      return ErrParameterInvalidName
 		}
 		return err
 	}

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -81,7 +81,13 @@ func (ps *ParameterStore) getParameter(input *ssm.GetParameterInput) (*Parameter
 	}, nil
 }
 
-func (ps *ParameterStore) PutSecureParameter(name, value, kmsID string) error {
+func (ps *ParameterStore) PutSecureParameter(name, value string, overwrite bool) error {
+  return ps.putSecureParameterWrapper(name, value, "", overwrite)
+}
+func (ps *ParameterStore) PutSecureParameterWithCMK(name, value string, overwrite bool, kmsID string) error {
+  return ps.putSecureParameterWrapper(name, value, kmsID, overwrite)
+}
+func (ps *ParameterStore) putSecureParameterWrapper(name, value, kmsID string, overwrite bool) error {
 	if name == "" {
 		return ErrParameterInvalidName
 	}
@@ -92,6 +98,7 @@ func (ps *ParameterStore) PutSecureParameter(name, value, kmsID string) error {
 	if kmsID != "" {
 		input.SetKeyId(kmsID)
 	}
+  input.SetOverwrite(overwrite)
 
   if err := input.Validate(); err != nil {
     return err

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -85,9 +85,22 @@ func (ps *ParameterStore) getParameter(input *ssm.GetParameterInput) (*Parameter
 	}, nil
 }
 
+//PutSecureParameter is setting the parameter with the given name to a passed in value.
+//Allow overwriting the value of the parameter already exists, otherwise an error is returned
+//For example a request with name as '/my-service/dev/param-1':
+//Will set the parameter value if exists or ErrParameterInvalidName if parameter already exists or is empty
+// and `overwrite` is false. The `ssm:PutParameter` permission is required to the
+//`arn:aws:ssm:aws-region:aws-account-id:/my-service/dev/param-1` resource
 func (ps *ParameterStore) PutSecureParameter(name, value string, overwrite bool) error {
 	return ps.putSecureParameterWrapper(name, value, "", overwrite)
 }
+
+//PutSecureParameterWithCMK is the same as PutSecureParameter but with a passed in CMK (Customer Master Key)
+//For example a request with name as '/my-service/dev/param-1' and a `kmsID` of 'foo':
+//Will set the parameter value if exists or ErrParameterInvalidName if parameter already exists or is empty
+// and `overwrite` is false. The `ssm:PutParameter` permission is required to the
+//`arn:aws:ssm:aws-region:aws-account-id:/my-service/dev/param-1` resource
+// The `kms:Encrypt` permission is required to the `arn:aws:kms:us-east-1:710015040892:key/foo`
 func (ps *ParameterStore) PutSecureParameterWithCMK(name, value string, overwrite bool, kmsID string) error {
 	return ps.putSecureParameterWrapper(name, value, kmsID, overwrite)
 }

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -36,6 +36,9 @@ func (ps *ParameterStore) GetAllParametersByPath(path string, decrypt bool) (*Pa
 	var input = &ssm.GetParametersByPathInput{}
 	input.SetWithDecryption(decrypt)
 	input.SetPath(path)
+  // yes, this is hard-coded, but if you have a directory of more than 100 records, maybe you 
+  // should think about re-organizing :)
+  input.SetMaxResults(100)
 	return ps.getParameters(input)
 }
 

--- a/parameter_store_client.go
+++ b/parameter_store_client.go
@@ -38,7 +38,7 @@ func (ps *ParameterStore) GetAllParametersByPath(path string, decrypt bool) (*Pa
 	input.SetPath(path)
   // yes, this is hard-coded, but if you have a directory of more than 100 records, maybe you 
   // should think about re-organizing :)
-  input.SetMaxResults(100)
+  input.SetMaxResults(50)
 	return ps.getParameters(input)
 }
 

--- a/parameter_store_client_test.go
+++ b/parameter_store_client_test.go
@@ -124,7 +124,7 @@ func TestClient_GetParametersByPath(t *testing.T) {
 							Parameters: getParameters(),
 						},
 					},
-          {
+					{
 						MoreParamsLeft: true,
 						Output: ssm.GetParametersByPathOutput{
 							Parameters: getParameters2(),
@@ -173,9 +173,9 @@ func getParameters() []*ssm.Parameter {
 }
 
 func getParameters2() []*ssm.Parameter {
-  return []*ssm.Parameter{
-    param3,
-  }
+	return []*ssm.Parameter{
+		param3,
+	}
 }
 
 func TestParameterStore_GetParameter(t *testing.T) {

--- a/parameter_store_client_test.go
+++ b/parameter_store_client_test.go
@@ -205,7 +205,7 @@ func TestParameterStore_PutSecureParameter(t *testing.T) {
 	overwriteFalse := false
 	tests := []struct {
 		name           string
-		ssmClient      ssmClient
+		ssmClient      *stubSSMClient
 		parameterName  string
 		parameterValue string
 		overwrite      bool
@@ -252,10 +252,8 @@ func TestParameterStore_PutSecureParameter(t *testing.T) {
 			if err != test.expectedError {
 				t.Errorf(`Unexpected error: got %d, expected %d`, err, test.expectedError)
 			}
-			fullStubClient := test.ssmClient.(*stubSSMClient)
-			fmt.Printf("fullStubClient: %+v", fullStubClient)
-			if !reflect.DeepEqual((*fullStubClient).PutParameterInputReceived, test.expectedOutput) {
-				t.Errorf(`Unexpected parameter: got %v, expected %v`, (*fullStubClient).PutParameterInputReceived, test.expectedOutput)
+			if !reflect.DeepEqual(test.ssmClient.PutParameterInputReceived, test.expectedOutput) {
+				t.Errorf(`Unexpected parameter: got %v, expected %v`, test.ssmClient.PutParameterInputReceived, test.expectedOutput)
 			}
 		})
 	}
@@ -269,7 +267,7 @@ func TestParameterStore_PutSecureParameterWithCMK(t *testing.T) {
 	kmsID := "super-secret-kms"
 	tests := []struct {
 		name           string
-		ssmClient      ssmClient
+		ssmClient      *stubSSMClient
 		parameterName  string
 		parameterValue string
 		overwrite      bool
@@ -318,9 +316,8 @@ func TestParameterStore_PutSecureParameterWithCMK(t *testing.T) {
 			if err != test.expectedError {
 				t.Errorf(`Unexpected error: got %d, expected %d`, err, test.expectedError)
 			}
-			fullStubClient := test.ssmClient.(*stubSSMClient)
-			if !reflect.DeepEqual(fullStubClient.PutParameterInputReceived, test.expectedOutput) {
-				t.Error(`Unexpected parameter`, fullStubClient.PutParameterInputReceived, test.expectedOutput)
+			if !reflect.DeepEqual(test.ssmClient.PutParameterInputReceived, test.expectedOutput) {
+				t.Errorf(`Unexpected parameter: got %v, expected %v`, test.ssmClient.PutParameterInputReceived, test.expectedOutput)
 			}
 		})
 	}

--- a/parameter_store_client_test.go
+++ b/parameter_store_client_test.go
@@ -2,10 +2,11 @@ package awsssm
 
 import (
 	"errors"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/ssm"
 	"reflect"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
 var param1 = new(ssm.Parameter).
@@ -33,6 +34,12 @@ func (s stubSSMClient) GetParametersByPath(input *ssm.GetParametersByPathInput) 
 
 func (s stubSSMClient) GetParameter(input *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 	return s.GetParameterOutput, s.GetParameterError
+}
+
+// we don't really use this because there isn't much to actually test for PutParameter
+// it accepts an input and either returns an error or nil--that's it
+func (s stubSSMClient) PutParameter(input *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+  return nil, nil
 }
 
 func TestClient_GetParametersByPath(t *testing.T) {


### PR DESCRIPTION
* Add easier way to set secure SSM parameters
* recursively get parameters for a given path. By recursive, I mean that it gets more than the limit of 10 parameters per invocation, which is an AWS API limit.