### PR TITLE
feat: expose key value map

### DIFF
--- a/parameter.go
+++ b/parameter.go
@@ -90,3 +90,8 @@ func (p *Parameters) getKeyValueMap() map[string]string {
 	}
 	return keyValue
 }
+
+// GetAllValues returns a map with all the keys and values in the store.
+func (p *Parameters) GetAllValues() map[string]string {
+	return p.getKeyValueMap()
+}

--- a/parameter_test.go
+++ b/parameter_test.go
@@ -154,6 +154,35 @@ func TestParameters_Read(t *testing.T) {
 	}
 }
 
+func TestParameters_GetAllValues(t *testing.T) {
+	tests := []struct {
+		name       string
+		basePath   string
+		parameters map[string]*Parameter
+	}{
+		{
+			name:       "GetAllValues default map",
+			basePath:   "/my-service/dev/",
+			parameters: getParametersMap(),
+		},
+		{
+			name:       "GetAllValues random map",
+			basePath:   "/my-service/dev/",
+			parameters: getRandomParametersMap(1000, 10),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parameter := NewParameters(test.basePath, test.parameters)
+
+			mp := parameter.GetAllValues()
+			if len(mp) != len(test.parameters) {
+				t.Errorf(`Unexpected value: got %v, expected %v`, len(mp), len(test.parameters))
+			}
+		})
+	}
+}
+
 func getParametersMap() map[string]*Parameter {
 	return map[string]*Parameter{
 		"/my-service/dev/DB_PASSWORD": {Value: param1.Value},


### PR DESCRIPTION
This commit exposes the internal key value map using a new method
GetAllValues which returns the map.

Closes #19