### PR TITLE
fix: prevent script injection in AutoReady for Review workflow

### DIFF
--- a/.github/workflows/auto-ready-for-review.yml
+++ b/.github/workflows/auto-ready-for-review.yml
@@ -58,10 +58,11 @@ jobs:
         id: gate
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         shell: bash
         run: |
             set -euo pipefail
-            pr_json="$(gh pr view ${{ inputs.pr_number }} --json isDraft,labels)"
+            pr_json="$(gh pr view "$PR_NUMBER" --json isDraft,labels)"
             is_draft="$(echo "$pr_json" | jq -r '.isDraft')"
             has_label="$(echo "$pr_json" | jq -r '.labels | map(.name) | index("auto-ready-for-review") | if . == null then "false" else "true" end')"
 
@@ -110,17 +111,19 @@ jobs:
         if: steps.gate.outputs.ok == 'true' && steps.check-all.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         shell: bash
         run: |
-          gh pr ready "${{ inputs.pr_number }}"
+          gh pr ready "$PR_NUMBER"
 
       - name: "🧹 Remove auto label"
         if: steps.gate.outputs.ok == 'true' && steps.check-all.outcome == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
         shell: bash
         run: |
-          gh pr edit "${{ inputs.pr_number }}" --remove-label "auto-ready-for-review"
+          gh pr edit "$PR_NUMBER" --remove-label "auto-ready-for-review"
 
   otel_cicd_export:
     name: OpenTelemetry Export Trace


### PR DESCRIPTION
## Summary
- `inputs.pr_number` was interpolated directly into `run:` shell scripts in three steps of `.github/workflows/auto-ready-for-review.yml`, allowing arbitrary shell command execution via a crafted `pr_number` value (GitHub Actions performs textual substitution before bash runs).
- The workflow has access to `AUTO_APPROVER_PRIVATE_KEY`, so a successful injection could exfiltrate that secret.
- Fix: pass `inputs.pr_number` through an `env:` block (`PR_NUMBER`) and reference it as a shell variable (`"$PR_NUMBER"`) instead of interpolating the expression directly into the script body.

Flagged by Wiz: "Publicly exposed CI workflow with access to secrets vulnerable to script injection" (Critical).

Note: this workflow file is templated from `go-library-template` (see the `DO NOT EDIT` header) — the same fix has been applied there in a companion PR (PaddleHQ/go-library-template#612) so future syncs don't reintroduce this.

## Test plan
- [ ] Confirm workflow YAML is valid (Actions lint / dry run)
- [ ] Trigger `AutoReady for Review` via `workflow_dispatch` on a test PR and confirm gate check, mark-ready, and label removal still work correctly

Linear: https://linear.app/paddle/issue/SEC-521
