### PR TITLE
Bump go directive from 1.24 to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/PaddleHQ/go-aws-ssm
 
-go 1.24
+go 1.25
 
 require (
 	github.com/aws/aws-sdk-go v1.48.15


### PR DESCRIPTION
### Checklist:
- [x] __Simple__:     _Is this code as simple as possible? Could it be achieved in a different way? Is there an open source project that already does this?_
- [x] __Together__:   _Have you worked with others on this change? Will it be a surprise to the reviewer? Will this change be communicated with other engineers?_
- [x] __For Others__: _Is the code readable and well commented? Will it be understandable when read by an engineer in the distant future? Does it "make the boat go faster"?_

### Semver:
`MINOR`: raises the minimum Go version consumers need. No API change, and every Paddle service is already on 1.25.x, so nothing downstream should notice — but it is a consumer-visible requirement, so it is not a patch.

### What has been done:
Go 1.24 is end-of-life. With 1.26 released only 1.25 and 1.26 receive security fixes, so CI here was building with an unpatched toolchain.

It also fixes two checks that have been failing on every PR in this repo. Both install a Go tool via `go install` under a pinned local toolchain, and both tools now require Go 1.25 or newer — `gorelease` on `Check API compatibility`, and `gomajor` on `Check for major dependency updates`. Since `.github/actions/setup-go` derives the Go version solely from this directive, the single line is the whole fix.

Kept minor-only (`go 1.25`, not `go 1.25.x`) per the library convention — services pin patches, libraries do not. 1.25 rather than 1.26 keeps the consumer floor on the older of the two supported releases.

Part of the Go 1.25 rollout in [APPEX-963](https://linear.app/paddle/issue/APPEX-963/roll-out-go-125-across-the-go-library-and-tooling-estate). This repo is one of 14 dependency-leaf libraries — it requires no other PaddleHQ module and does not use `testing/synctest`, so the change is self-contained and has no ordering constraint against its siblings.

Note `GOEXPERIMENT: synctest` is deliberately left in place. Go 1.25 still accepts it; it must only be removed once the whole estate is ≥1.25, and before any move to 1.26, which rejects the flag outright.

### How to test:
`pdl . test`

Verified locally against `go1.25.5`: build, vet and tests all pass, and `go mod tidy` reports no drift.
